### PR TITLE
upgrade on Linux support

### DIFF
--- a/moom.el
+++ b/moom.el
@@ -387,8 +387,8 @@ the actual pixel width will not exceed the WIDTH."
         ((and (eq window-system 'x)
               (version< emacs-version "26.0")) '(0 8))
         ((member window-system '(ns mac)) '(0 0))
-        (t (let ((workarea (moom--frame-monitor-workarea)))
-             (list (nth 0 workarea) (nth 1 workarea))))))
+        ((eq window-system 'x) '(10 8))
+        (t '(0 0))))
 
 (defun moom--screen-grid ()
   "Adjustment of `set-frame-position'."
@@ -417,8 +417,8 @@ OPTIONS controls grid and bound.  See `moom--pos-options'."
   (when (listp posx)
     (setq posx (nth 1 posx)))
   (setq posx (- posx (nth 0 moom--screen-grid)))
-  (when (and (plist-get options :bound)
-             (not (eq window-system 'ns))) ;; TODO: support others if possible
+  (when (or (plist-get options :bound)
+            (not (eq window-system 'ns))) ;; TODO: support others if possible
     (let ((bounds-left 0) ;; TODO Shall be checked
           (bounds-right (- (display-pixel-width)
                            (moom--frame-pixel-width))))
@@ -427,9 +427,9 @@ OPTIONS controls grid and bound.  See `moom--pos-options'."
                        (t posx)))))
   (unless (plist-get options :grid)
     (plist-put options :grid
-               (if (or (eq window-system 'ns)
-                       (and (eq window-system 'x)
-                            (version< "26.0" emacs-version)))
+               (if (eq window-system 'ns)
+                   ;; (and (eq window-system 'x)
+                   ;;      (version< "26.0" emacs-version))
                    'screen 'virtual)))
   (cond ((eq (plist-get options :grid) 'virtual)
          (setq posx (- posx (nth 0 (moom--screen-grid))))
@@ -448,8 +448,8 @@ OPTIONS controls grid and bound.  See `moom--pos-options'."
   (when (listp posy)
     (setq posy (nth 1 posy)))
   (setq posy (- posy (nth 1 moom--screen-grid)))
-  (when (and (plist-get options :bound)
-             (not (eq window-system 'ns))) ;; TODO: support others if possible
+  (when (or (plist-get options :bound)
+            (not (eq window-system 'ns))) ;; TODO: support others if possible
     (let ((bounds-top 0)
           (bounds-bottom (- (display-pixel-height)
                             (moom--frame-pixel-height))))
@@ -458,9 +458,9 @@ OPTIONS controls grid and bound.  See `moom--pos-options'."
                        (t posy)))))
   (unless options
     (plist-put options :grid
-               (if (or (eq window-system 'ns)
-                       (and (eq window-system 'x)
-                            (version< "26.0" emacs-version)))
+               (if (eq window-system 'ns)
+                   ;; (and (eq window-system 'x)
+                   ;;      (version< "26.0" emacs-version))
                    'screen 'virtual)))
   (cond ((eq (plist-get options :grid) 'virtual)
          (setq posy (- posy (nth 1 (moom--screen-grid))))
@@ -814,7 +814,7 @@ If PLIST is nil, `moom-fill-band-options' is used."
 (defun moom-move-frame-right (&optional pixel)
   "PIXEL move the current frame to right."
   (interactive)
-  (let* ((pos-x (moom--pos-x (moom--frame-left)))
+  (let* ((pos-x (moom--frame-left))
          (pos-y (moom--frame-top))
          (new-pos-x (+ pos-x (or pixel
                                  (moom--shift-amount 'right)))))
@@ -832,7 +832,7 @@ If PLIST is nil, `moom-fill-band-options' is used."
 (defun moom-move-frame-left (&optional pixel)
   "PIXEL move the current frame to left."
   (interactive)
-  (let* ((pos-x (moom--pos-x (moom--frame-left)))
+  (let* ((pos-x (moom--frame-left))
          (pos-y (moom--frame-top))
          (new-pos-x (- pos-x (or pixel
                                  (moom--shift-amount 'left)))))

--- a/moom.el
+++ b/moom.el
@@ -210,6 +210,8 @@ For function `display-line-numbers-mode',
     (setq moom--screen-margin (moom--default-screen-margin)))
   (unless moom--virtual-grid
     (setq moom--virtual-grid (moom--virtual-grid)))
+  (unless moom--screen-grid
+    (setq moom--screen-grid (moom--screen-grid)))
   (unless (eq (setq moom--frame-width moom-frame-width-single) 80)
     (set-frame-width nil moom--frame-width))
   (moom--make-frame-height-list)
@@ -388,17 +390,26 @@ the actual pixel width will not exceed the WIDTH."
         (t (let ((workarea (moom--frame-monitor-workarea)))
              (list (nth 0 workarea) (nth 1 workarea))))))
 
+(defun moom--screen-grid ()
+  "Adjustment of `set-frame-position'."
+  (cond ((eq window-system 'w32) '(8 0))
+        ((and (eq window-system 'x)
+              (version< emacs-version "26.0")) '(10 0))
+        (t '(0 0))))
+
 (defun moom--frame-left ()
   "Return outer left position."
   (let ((left (frame-parameter nil 'left)))
     (+ (if (listp left) (nth 1 left) left)
-       (nth 0 moom--virtual-grid))))
+       (nth 0 moom--virtual-grid)
+       (nth 0 moom--screen-grid))))
 
 (defun moom--frame-top ()
   "Return outer top position."
   (let ((top (frame-parameter nil 'top)))
     (+ (if (listp top) (nth 1 top) top)
-       (nth 1 moom--virtual-grid))))
+       (nth 1 moom--virtual-grid)
+       (nth 1 moom--screen-grid))))
 
 (defun moom--pos-x (posx &optional options)
   "Extract a value from POSX.

--- a/moom.el
+++ b/moom.el
@@ -385,7 +385,7 @@ the actual pixel width will not exceed the WIDTH."
   "Adjustment of `prame-parameter'."
   (cond ((eq window-system 'w32) '(-16 0))
         ((and (eq window-system 'x)
-              (version< emacs-version "26.0")) '(0 8))
+              (version< emacs-version "26.0")) '(0 27))
         ((member window-system '(ns mac)) '(0 0))
         ((eq window-system 'x) '(10 8))
         (t '(0 0))))
@@ -394,7 +394,7 @@ the actual pixel width will not exceed the WIDTH."
   "Adjustment of `set-frame-position'."
   (cond ((eq window-system 'w32) '(8 0))
         ((and (eq window-system 'x)
-              (version< emacs-version "26.0")) '(10 0))
+              (version< emacs-version "26.0")) '(10 -19))
         (t '(0 0))))
 
 (defun moom--frame-left ()
@@ -419,20 +419,16 @@ OPTIONS controls grid and bound.  See `moom--pos-options'."
   (setq posx (- posx (nth 0 moom--screen-grid)))
   (when (or (plist-get options :bound)
             (not (eq window-system 'ns))) ;; TODO: support others if possible
-    (let ((bounds-left 0) ;; TODO Shall be checked
+    (let ((bounds-left (- (nth 0 moom--screen-grid)))
           (bounds-right (- (display-pixel-width)
                            (moom--frame-pixel-width))))
       (setq posx (cond ((< posx bounds-left) bounds-left)
                        ((> posx bounds-right) bounds-right)
                        (t posx)))))
-  (unless (plist-get options :grid)
-    (plist-put options :grid
-               (if (eq window-system 'ns)
-                   ;; (and (eq window-system 'x)
-                   ;;      (version< "26.0" emacs-version))
-                   'screen 'virtual)))
+  (unless options
+    (setq options (if (member window-system '(ns mac))
+                      '(:grid screen) '(:grid virtual))))
   (cond ((eq (plist-get options :grid) 'virtual)
-         (setq posx (- posx (nth 0 (moom--screen-grid))))
          (let ((pw (- (display-pixel-width) (moom--frame-pixel-width))))
            (if (< posx 0)
                (- posx (+ pw (nth 0 moom--virtual-grid)))
@@ -457,13 +453,9 @@ OPTIONS controls grid and bound.  See `moom--pos-options'."
                        ((> posy bounds-bottom) bounds-bottom)
                        (t posy)))))
   (unless options
-    (plist-put options :grid
-               (if (eq window-system 'ns)
-                   ;; (and (eq window-system 'x)
-                   ;;      (version< "26.0" emacs-version))
-                   'screen 'virtual)))
+    (setq options (if (member window-system '(ns mac))
+                      '(:grid screen) '(:grid virtual))))
   (cond ((eq (plist-get options :grid) 'virtual)
-         (setq posy (- posy (nth 1 (moom--screen-grid))))
          (+ posy (- (nth 1 (moom--frame-monitor-workarea))
                     (nth 1 moom--virtual-grid))))
         ((eq (plist-get options :grid) 'screen)


### PR DESCRIPTION
- moom--virtual-grid and moom--screen-grid are introduced to align frame position
- moom--pos-x and moom--pox-y has been refined to easily use set-frame-position
- Tested:
  [X] macOS(Catalina), emacs 27.0.91
  [X] CentOS(8.2), emacs:26.1, GTK:3.22.30
  [X] Ubuntu(20.04), emacs:26.3, GTK:3.24.14
  [X] openSUSE(15.1), emacs:26.3, GTK: 3.22.30
  [X] openSUSE(15.1), emacs:25.3, GTK:3.22.30

We need further tests of the latest code.